### PR TITLE
Added additional check to work nicely with Freshdesk API

### DIFF
--- a/CreateTicketHttp/CreateTicket.cs
+++ b/CreateTicketHttp/CreateTicket.cs
@@ -275,7 +275,7 @@ namespace CreateTicketHttp
 
                 
                // Reason 2
-               if(reasonTwo != null)
+               if(reasonTwo != null && reasonTwo != "")
                 {
                     WriteBoundaryBytes(rs, boundary, false);
                     WriteContentDispositionFormDataHeader(rs, "custom_fields[cf_reason_2]");
@@ -320,7 +320,7 @@ namespace CreateTicketHttp
                 }
                 
                 // Ongoing request
-                if(isOngoing != "false")
+                if(isOngoing != "false" && isOngoing != "")
                 {
                     WriteBoundaryBytes(rs, boundary, false);
                     WriteContentDispositionFormDataHeader(rs, "custom_fields[cf_ongoing]");


### PR DESCRIPTION
When submitting a ticket from the web form, the function app would receive reasonTwoVal as an empty string. This would cause an error when submitting to Freshdesk API. Added an additional check to prevent this error.